### PR TITLE
Fix test flakes/errors

### DIFF
--- a/cmd/promlts/sidecar.go
+++ b/cmd/promlts/sidecar.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"net/http"
+	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/improbable-eng/promlts/pkg/shipper"
@@ -106,7 +107,7 @@ func runSidecar(
 
 		ctx, cancel := context.WithCancel(context.Background())
 		g.Add(func() error {
-			return errors.Wrap(s.Run(ctx), "run block shipper")
+			return errors.Wrap(s.Run(ctx, 30*time.Second), "run block shipper")
 		}, func(error) {
 			cancel()
 		})

--- a/pkg/shipper/shipper.go
+++ b/pkg/shipper/shipper.go
@@ -40,6 +40,9 @@ func New(
 	remote Remote,
 	match func(os.FileInfo) bool,
 ) *Shipper {
+	if logger == nil {
+		logger = log.NewNopLogger()
+	}
 	return &Shipper{
 		logger: logger,
 		dir:    dir,
@@ -47,8 +50,6 @@ func New(
 		match:  match,
 	}
 }
-
-const syncInterval = 5 * time.Second
 
 // IsULIDDir returns true if the described file is a directory with a name that is
 // a valid ULID.
@@ -61,7 +62,7 @@ func IsULIDDir(fi os.FileInfo) bool {
 }
 
 // Run the shipper.
-func (s *Shipper) Run(ctx context.Context) error {
+func (s *Shipper) Run(ctx context.Context, syncInterval time.Duration) error {
 	tick := time.NewTicker(syncInterval)
 	defer tick.Stop()
 

--- a/pkg/shipper/shipper_test.go
+++ b/pkg/shipper/shipper_test.go
@@ -1,19 +1,19 @@
 package shipper
 
 import (
+	"math/rand"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/oklog/ulid"
 
 	"context"
 	"io/ioutil"
-	"time"
 
-	"fmt"
 	"os"
 
-	"github.com/go-kit/kit/log"
 	"github.com/improbable-eng/promlts/pkg/testutil"
-	"github.com/prometheus/prometheus/pkg/timestamp"
-	"github.com/prometheus/tsdb/labels"
 )
 
 type inMemStorage struct {
@@ -34,6 +34,7 @@ func (r *inMemStorage) Exists(_ context.Context, id string) (bool, error) {
 }
 
 func (r *inMemStorage) Upload(_ context.Context, dir string) error {
+	r.t.Logf("upload called: %s", dir)
 	// Double check if shipper checks Exists method properly.
 	_, exists := r.dirs[dir]
 	testutil.Assert(r.t, !exists, "target should not exists")
@@ -42,75 +43,43 @@ func (r *inMemStorage) Upload(_ context.Context, dir string) error {
 	return nil
 }
 
-func TestShipper_UploadsBlocksFromProm(t *testing.T) {
-	logger := log.NewNopLogger()
-
+func TestShipper_UploadULIDDirs(t *testing.T) {
 	dir, err := ioutil.TempDir("", "shipper-test-snapshots")
 	testutil.Ok(t, err)
 	defer os.RemoveAll(dir)
 
-	p, err := testutil.NewTSDB()
-	testutil.Ok(t, err)
-	defer p.Close()
-
 	storage := newInMemStorage(t)
-	shipper := New(
-		logger,
-		nil,
-		dir,
-		storage,
-		IsULIDDir,
-	)
+	shipper := New(nil, nil, dir, storage, IsULIDDir)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	// Start shipping blocks.
-	go func() { testutil.Ok(t, shipper.Run(ctx)) }()
+	go func() { testutil.Ok(t, shipper.Run(ctx, 50*time.Millisecond)) }()
 
-	baseT := timestamp.FromTime(time.Now())
+	// Create 10 directories with ULIDs as names
+	const numDirs = 10
+	rands := rand.New(rand.NewSource(0))
 
-	// Produce 10 different blocks and wait max 5 seconds for shipper to ship them.
-	for i := int64(0); i < 10; i++ {
-		ctx, cancel2 := context.WithTimeout(ctx, 5*time.Second)
-		defer cancel2()
+	var expected []string
 
-		// Add fake intput.
-		a := p.Appender()
+	for i := 0; i < numDirs; i++ {
+		id := ulid.MustNew(uint64(i), rands)
+		bdir := filepath.Join(dir, id.String())
+		tmp := bdir + ".tmp"
 
-		// Make labels, timestamp and values unique.
-		labelVal := fmt.Sprintf("b%v", i)
-		baseT := baseT + (i * 300)
-		baseV := float64(i * 3)
+		testutil.Ok(t, os.Mkdir(tmp, 0777))
+		testutil.Ok(t, os.Rename(tmp, bdir))
 
-		a.Add(labels.FromStrings("a", labelVal), baseT+100, baseV+1)
-		a.Add(labels.FromStrings("a", labelVal), baseT+200, baseV+2)
-		a.Add(labels.FromStrings("a", labelVal), baseT+300, baseV+3)
-		testutil.Ok(t, a.Commit())
-
-		testutil.Ok(t, p.Snapshot(dir))
-		waitForShipment(t, ctx, storage, len(p.Blocks()))
+		expected = append(expected, bdir)
 	}
 
-	blocks := p.Blocks()
-	// Check if storage matches with that tsdb claims to have at the end.
-	testutil.Equals(t, len(storage.dirs), len(blocks))
-	for _, b := range blocks {
-		_, exists := storage.dirs[b.Dir()]
-		testutil.Assert(t, exists, "did not found block %s in shipped data", b.Dir())
-	}
-}
+	time.Sleep(500 * time.Millisecond)
 
-func waitForShipment(t *testing.T, ctx context.Context, storage *inMemStorage, expectedBlocks int) {
-	for {
-		if ctx.Err() != nil {
-			t.Errorf("context cancelled. not seen expected blocks (%d) in storage in time", expectedBlocks)
-			t.FailNow()
-		}
-
-		if len(storage.dirs) >= expectedBlocks {
-			return
-		}
-		time.Sleep(100 * time.Millisecond)
+	for _, exp := range expected {
+		ok, err := storage.Exists(ctx, exp)
+		testutil.Ok(t, err)
+		testutil.Assert(t, ok, "ULID directory %s expected in store", exp)
 	}
+	testutil.Equals(t, numDirs, len(storage.dirs))
 }

--- a/pkg/testutil/prometheus.go
+++ b/pkg/testutil/prometheus.go
@@ -57,6 +57,8 @@ func NewPrometheus(address string) (*Prometheus, error) {
 // Start running the Prometheus instance and return.
 func (p *Prometheus) Start() error {
 	p.running = true
+	time.Sleep(time.Second / 2)
+
 	if err := p.db.Close(); err != nil {
 		return err
 	}
@@ -73,7 +75,7 @@ func (p *Prometheus) Start() error {
 			fmt.Fprintln(os.Stderr, string(b))
 		}
 	}()
-	time.Sleep(time.Second)
+	time.Sleep(2 * time.Second)
 
 	return nil
 }


### PR DESCRIPTION
The shipper is only concerned with detecting and passing directories or
files to a remote uploader. It's agnostic to TSDB itself so we can
simplify the unit test accordingly.

Fixes #20 